### PR TITLE
fix(github): handle epic seed fields safely

### DIFF
--- a/scripts/setup-requirements-github-project.ps1
+++ b/scripts/setup-requirements-github-project.ps1
@@ -513,8 +513,9 @@ function New-IssueBody {
     "- Requirement Type: $($IssueDefinition.requirementType)"
   )
 
-  if (-not [string]::IsNullOrWhiteSpace($IssueDefinition.parentKey)) {
-    $parentDefinition = $IssueDefinitionsByKey[$IssueDefinition.parentKey]
+  $parentKey = Get-PropertyValue -Object $IssueDefinition -Name 'parentKey'
+  if (-not [string]::IsNullOrWhiteSpace($parentKey)) {
+    $parentDefinition = $IssueDefinitionsByKey[$parentKey]
     $phaseLines += "- Parent Epic: $($parentDefinition.title)"
   }
 


### PR DESCRIPTION
## Summary

- Handles optional parentKey values when generating issue bodies for epic seed items.
- Keeps the requirements project seed script compatible with PowerShell StrictMode.

## Validation

- powershell -ExecutionPolicy Bypass -File .\\scripts\\validate-github-governance.ps1 -Owner TurkishKEBAB