### PR TITLE
fix(github): handle parent epic field safely

### DIFF
--- a/scripts/setup-requirements-github-project.ps1
+++ b/scripts/setup-requirements-github-project.ps1
@@ -808,8 +808,9 @@ foreach ($issueDefinition in $orderedIssues) {
   Set-ProjectFieldValue -ProjectId $projectId -ItemId $itemId -FieldMap $fieldMap -FieldName 'Source Doc' -Value ($issueDefinition.sourceDocuments -join ', ')
   Set-ProjectFieldValue -ProjectId $projectId -ItemId $itemId -FieldMap $fieldMap -FieldName 'Acceptance Criteria' -Value $issueDefinition.acceptanceSummary
 
-  if (-not [string]::IsNullOrWhiteSpace($issueDefinition.parentKey)) {
-    $parentTitle = $issueDefinitionsByKey[$issueDefinition.parentKey].title
+  $parentKey = Get-PropertyValue -Object $issueDefinition -Name 'parentKey'
+  if (-not [string]::IsNullOrWhiteSpace($parentKey)) {
+    $parentTitle = $issueDefinitionsByKey[$parentKey].title
     Set-ProjectFieldValue -ProjectId $projectId -ItemId $itemId -FieldMap $fieldMap -FieldName 'Parent Epic' -Value $parentTitle
   }
 


### PR DESCRIPTION
## Summary

- Uses safe property access when setting the Parent Epic project field.
- Keeps epic seed items compatible with PowerShell StrictMode.

## Validation

- powershell -ExecutionPolicy Bypass -File .\\scripts\\validate-github-governance.ps1 -Owner TurkishKEBAB