### PR TITLE
Add thesis backlog governance automation

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,9 +13,30 @@ permissions:
   contents: read
   security-events: write
   actions: read
+  packages: read
 
 jobs:
-  analyze:
+  analyze-actions:
+    name: Analyze GitHub Actions
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: actions
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:actions"
+
+  analyze-javascript-typescript:
     name: Analyze JavaScript and TypeScript
     runs-on: ubuntu-latest
 
@@ -37,7 +58,7 @@ jobs:
 
       - name: Planning-only repository notice
         if: steps.app.outputs.exists == 'false'
-        run: echo "No package.json yet; CodeQL is armed and will run after the first app scaffold."
+        run: echo "No package.json yet; JavaScript/TypeScript CodeQL is armed and will run after the first app scaffold."
 
       - name: Initialize CodeQL
         if: steps.app.outputs.exists == 'true'
@@ -53,3 +74,5 @@ jobs:
       - name: Perform CodeQL Analysis
         if: steps.app.outputs.exists == 'true'
         uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:javascript-typescript"

--- a/docs/schemas/requirements-project.schema.json
+++ b/docs/schemas/requirements-project.schema.json
@@ -12,6 +12,22 @@
       "required": ["title", "fields", "views"],
       "properties": {
         "title": { "type": "string", "minLength": 1 },
+        "milestones": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["title", "phase", "description"],
+            "properties": {
+              "title": { "type": "string", "minLength": 1 },
+              "phase": {
+                "type": "string",
+                "enum": ["Faz 1", "Faz 2", "Faz 3"]
+              },
+              "description": { "type": "string", "minLength": 1 }
+            }
+          }
+        },
         "fields": {
           "type": "array",
           "minItems": 1,
@@ -47,11 +63,39 @@
               },
               "filter": { "type": "string" },
               "groupBy": { "type": "string" },
+              "columnBy": { "type": "string" },
+              "swimlanes": { "type": "string" },
+              "sliceBy": { "type": "string" },
+              "dateField": { "type": "string" },
               "sortBy": {
+                "type": "array",
+                "items": {
+                  "oneOf": [
+                    { "type": "string" },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": ["field"],
+                      "properties": {
+                        "field": { "type": "string", "minLength": 1 },
+                        "direction": {
+                          "type": "string",
+                          "enum": ["asc", "desc", "ASC", "DESC"]
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              "visibleFields": {
                 "type": "array",
                 "items": { "type": "string" }
               },
-              "visibleFields": {
+              "fieldSums": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "notes": {
                 "type": "array",
                 "items": { "type": "string" }
               }
@@ -103,6 +147,12 @@
         "properties": {
           "key": { "type": "string", "minLength": 1 },
           "parentKey": { "type": "string", "minLength": 1 },
+          "milestone": { "type": "string", "minLength": 1 },
+          "blockedByKeys": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 },
+            "uniqueItems": true
+          },
           "kind": {
             "type": "string",
             "enum": ["epic", "issue"]

--- a/github-projects/README.md
+++ b/github-projects/README.md
@@ -25,8 +25,34 @@ This folder contains the seed data and automation for the `Agentic IDE - Thesis 
   - `Test Target`
   - `Thesis Evidence`
   - `Readiness`
+  - `Blocked by`
+  - `Blocking`
+  - `Dependency Count`
+  - `Blocking Count`
+  - `Child Issue Count`
+- Project views for:
+  - `Requirements Master`
+  - `Workflow Board`
+  - `Advisor Review`
+  - `By Phase`
+  - `Evidence Matrix`
+  - `Risks`
+  - `Dependency Map`
+  - `Dependency Map Detailed`
+  - `Faz 1 Readiness Gate`
+  - `Implementation Queue`
+  - `Implementation Queue Detailed`
+  - `VDD Research`
+  - `Safety & Privacy`
+  - `Quality Gates`
+  - `CI / Project Ops`
+  - `Roadmap`
 - Repository labels for epics, requirements, research items, and risks
 - Operational labels for bugs, dependencies, documentation, security, quality gates, and VDD research framing
+- Repository milestones (`Faz 1 - Implementation Readiness`, `Faz 2 - MVP`, `Faz 3 - Evaluation & Thesis`) auto-assigned from each issue's `Phase` field
+- Native GitHub parent / sub-issue links created from each issue's `parentKey` (epic relationship is wired through the real GraphQL `addSubIssue` mutation, not just the `Parent Epic` text field)
+- Native GitHub issue dependencies created from optional `blockedByKeys` entries (`blocked by` relationships are synced through GitHub's REST issue dependencies API)
+- Readable dependency summary fields are populated from the same source: `Blocked by`, `Blocking`, `Dependency Count`, `Blocking Count`, and `Child Issue Count`
 - Epic issues and requirement issues derived from the current thesis documents
 
 ## Why `Requirement Status` Instead Of `Status`
@@ -86,10 +112,10 @@ powershell -ExecutionPolicy Bypass -File .\scripts\setup-requirements-github-pro
 
 - The script is designed to be safely rerunnable for labels, fields, and issues.
 - Verification-Driven Development planning cards are seeded with `Requirement Status = Advisor Review` so the TDD/VDD stance, spiral requirements control, and implementation-verification separation can be discussed before approval.
-- View metadata in `requirements-analysis.json` records intended filters, grouping, sorting, and visible fields. GitHub's stable automation support for fine-grained Project view layout is limited, so final view tuning may still require one manual UI pass.
+- View metadata in `requirements-analysis.json` records intended filters, visible fields, grouping, sorting, board columns, swimlanes, roadmap date field, slice field, and field-sum intent.
 - Use the built-in GitHub Project `Status` field for workflow execution (`Backlog`, `Ready`, `In Progress`, `Review`, `Done`, `Deferred`). Use `Requirement Status` for thesis requirement maturity only.
-- Project view creation is best-effort because GitHub exposes fewer stable automation hooks for fine-grained view configuration than it does for fields and items.
-- If view creation succeeds, you still may want to fine-tune grouping and visible columns once in the GitHub UI.
+- Project view creation uses GitHub's REST Project views endpoint for user-owned projects (`/users/{user_id}/projectsV2/{project_number}/views`). Creating new views can include `visible_fields`; existing view updates are best-effort because GitHub's documented endpoint is creation-focused.
+- If a view already exists and GitHub rejects the automatic update, use the GitHub UI once to align that view with the seed. The `Dependency Map Detailed` view exists as a clean fallback when an older manually-created `Dependency Map` cannot be patched in place.
 - Recommended workflow columns for the built-in `Status` field are `Backlog`, `Ready`, `In Progress`, `Review`, `Done`, and `Deferred`.
 - `-SyncWorkflowStatus` sets epics to `Review`, Faz 1 P0 child issues to `Ready`, and the rest to `Backlog`; omit it after active development starts so day-to-day status is not reset.
 - `Readiness` is set automatically from the seed: advisor-review or Faz 1 P0 cards become `Ready`, approved/done cards become `Validated`, deferred/blocked cards become `Blocked`, and the rest stay `Needs Clarification`.

--- a/github-projects/requirements-analysis.json
+++ b/github-projects/requirements-analysis.json
@@ -1,6 +1,23 @@
 {
   "project": {
     "title": "Agentic IDE - Thesis Backlog",
+    "milestones": [
+      {
+        "title": "Faz 1 - Implementation Readiness",
+        "phase": "Faz 1",
+        "description": "Mimari kararlar, ADR'ler, readiness gate, schema'lar, validation CI ve VDD framing - implementasyon oncesi hazirlik fazi."
+      },
+      {
+        "title": "Faz 2 - MVP",
+        "phase": "Faz 2",
+        "description": "Editor, agent loop, diff approval, safety, retrieval ve onboarding - MVP implementasyon fazi."
+      },
+      {
+        "title": "Faz 3 - Evaluation & Thesis",
+        "phase": "Faz 3",
+        "description": "Benchmark calismasi, metric toplama, feature freeze, tez metni ve final deliverables."
+      }
+    ],
     "fields": [
       {
         "name": "Requirement Status",
@@ -100,6 +117,26 @@
           "Blocked",
           "Validated"
         ]
+      },
+      {
+        "name": "Blocked by",
+        "dataType": "TEXT"
+      },
+      {
+        "name": "Blocking",
+        "dataType": "TEXT"
+      },
+      {
+        "name": "Dependency Count",
+        "dataType": "NUMBER"
+      },
+      {
+        "name": "Blocking Count",
+        "dataType": "NUMBER"
+      },
+      {
+        "name": "Child Issue Count",
+        "dataType": "NUMBER"
       }
     ],
     "views": [
@@ -108,67 +145,452 @@
         "layout": "table",
         "groupBy": "Parent Epic",
         "sortBy": [
-          "Priority",
-          "Phase"
+          {
+            "field": "Phase",
+            "direction": "asc"
+          },
+          {
+            "field": "Priority",
+            "direction": "asc"
+          },
+          {
+            "field": "Parent Epic",
+            "direction": "asc"
+          }
         ],
         "visibleFields": [
+          "Title",
+          "Status",
           "Requirement Status",
           "Readiness",
-          "Area",
-          "Requirement Type",
           "Phase",
           "Priority",
+          "Area",
+          "Requirement Type",
+          "Parent issue",
+          "Parent Epic",
+          "Milestone",
           "MVP Scenario",
           "Risk",
           "Test Target",
-          "Thesis Evidence"
+          "Thesis Evidence",
+          "Blocked by",
+          "Blocking",
+          "Dependency Count",
+          "Blocking Count",
+          "Child Issue Count",
+          "Labels",
+          "Sub-issues progress",
+          "Linked pull requests"
+        ],
+        "fieldSums": [
+          "Dependency Count",
+          "Blocking Count",
+          "Child Issue Count"
+        ]
+      },
+      {
+        "name": "Workflow Board",
+        "layout": "board",
+        "columnBy": "Status",
+        "swimlanes": "Parent Epic",
+        "sortBy": [
+          {
+            "field": "Priority",
+            "direction": "asc"
+          }
+        ],
+        "visibleFields": [
+          "Title",
+          "Priority",
+          "Phase",
+          "Readiness",
+          "Parent Epic",
+          "Blocked by",
+          "Milestone",
+          "Labels",
+          "Linked pull requests"
         ]
       },
       {
         "name": "Advisor Review",
-        "layout": "board",
-        "filter": "Requirement Status:Advisor Review",
+        "layout": "table",
+        "filter": "requirement-status:\"Advisor Review\"",
         "groupBy": "Area",
+        "sortBy": [
+          {
+            "field": "Priority",
+            "direction": "asc"
+          },
+          {
+            "field": "Parent Epic",
+            "direction": "asc"
+          }
+        ],
         "visibleFields": [
-          "Priority",
+          "Title",
+          "Status",
+          "Requirement Status",
           "Readiness",
+          "Area",
+          "Priority",
           "Source Doc",
-          "Acceptance Criteria"
+          "Acceptance Criteria",
+          "Risk",
+          "Test Target",
+          "Thesis Evidence",
+          "Blocked by",
+          "Milestone"
         ]
       },
       {
         "name": "By Phase",
         "layout": "board",
-        "groupBy": "Phase",
+        "columnBy": "Phase",
+        "swimlanes": "Parent Epic",
+        "sortBy": [
+          {
+            "field": "Priority",
+            "direction": "asc"
+          }
+        ],
         "visibleFields": [
+          "Title",
+          "Status",
           "Requirement Status",
+          "Readiness",
+          "Priority",
+          "Parent Epic",
+          "Milestone",
+          "Blocked by"
+        ]
+      },
+      {
+        "name": "Evidence Matrix",
+        "layout": "table",
+        "groupBy": "MVP Scenario",
+        "sortBy": [
+          {
+            "field": "Phase",
+            "direction": "asc"
+          },
+          {
+            "field": "Priority",
+            "direction": "asc"
+          }
+        ],
+        "visibleFields": [
+          "Title",
+          "Phase",
+          "MVP Scenario",
+          "Test Target",
+          "Thesis Evidence",
+          "Acceptance Criteria",
+          "Risk",
+          "Requirement Status",
+          "Status",
+          "Readiness"
+        ]
+      },
+      {
+        "name": "Risks",
+        "layout": "table",
+        "filter": "requirement-type:Risk",
+        "groupBy": "Area",
+        "sortBy": [
+          {
+            "field": "Priority",
+            "direction": "asc"
+          }
+        ],
+        "visibleFields": [
+          "Title",
+          "Area",
+          "Phase",
           "Priority",
           "Readiness",
+          "Risk",
+          "Test Target",
+          "Thesis Evidence",
+          "Blocked by",
+          "Blocking",
+          "Labels",
+          "Milestone"
+        ]
+      },
+      {
+        "name": "Dependency Map",
+        "layout": "table",
+        "filter": "-label:epic",
+        "groupBy": "Parent Epic",
+        "sortBy": [
+          {
+            "field": "Phase",
+            "direction": "asc"
+          },
+          {
+            "field": "Priority",
+            "direction": "asc"
+          }
+        ],
+        "visibleFields": [
+          "Title",
+          "Status",
+          "Readiness",
+          "Phase",
+          "Priority",
+          "Parent issue",
+          "Parent Epic",
+          "Blocked by",
+          "Blocking",
+          "Dependency Count",
+          "Blocking Count",
+          "Child Issue Count",
+          "Sub-issues progress",
+          "Milestone",
+          "Labels"
+        ],
+        "fieldSums": [
+          "Dependency Count",
+          "Blocking Count",
+          "Child Issue Count"
+        ]
+      },
+      {
+        "name": "Dependency Map Detailed",
+        "layout": "table",
+        "filter": "-label:epic",
+        "groupBy": "Parent Epic",
+        "sortBy": [
+          {
+            "field": "Phase",
+            "direction": "asc"
+          },
+          {
+            "field": "Priority",
+            "direction": "asc"
+          }
+        ],
+        "visibleFields": [
+          "Title",
+          "Status",
+          "Readiness",
+          "Phase",
+          "Priority",
+          "Parent issue",
+          "Parent Epic",
+          "Blocked by",
+          "Blocking",
+          "Dependency Count",
+          "Blocking Count",
+          "Child Issue Count",
+          "Sub-issues progress",
+          "Milestone",
+          "Labels"
+        ],
+        "fieldSums": [
+          "Dependency Count",
+          "Blocking Count",
+          "Child Issue Count"
+        ],
+        "notes": [
+          "This duplicate detailed view is used when the existing manually-created Dependency Map cannot be updated by the REST API."
+        ]
+      },
+      {
+        "name": "Faz 1 Readiness Gate",
+        "layout": "table",
+        "filter": "phase:\"Faz 1\" priority:P0 -label:epic",
+        "groupBy": "Readiness",
+        "sortBy": [
+          {
+            "field": "Parent Epic",
+            "direction": "asc"
+          },
+          {
+            "field": "Priority",
+            "direction": "asc"
+          }
+        ],
+        "visibleFields": [
+          "Title",
+          "Requirement Status",
+          "Status",
+          "Readiness",
+          "Source Doc",
+          "Acceptance Criteria",
+          "Risk",
+          "Test Target",
+          "Thesis Evidence",
+          "Blocked by",
           "Parent Epic"
         ]
       },
       {
-        "name": "Roadmap",
-        "layout": "roadmap",
-        "groupBy": "Phase",
+        "name": "Implementation Queue",
+        "layout": "table",
+        "filter": "status:Ready -label:epic",
+        "groupBy": "Area",
+        "sortBy": [
+          {
+            "field": "Priority",
+            "direction": "asc"
+          },
+          {
+            "field": "Phase",
+            "direction": "asc"
+          }
+        ],
         "visibleFields": [
-          "Requirement Status",
+          "Title",
+          "Phase",
           "Priority",
-          "Target Date",
-          "Thesis Evidence"
+          "Readiness",
+          "Area",
+          "Parent Epic",
+          "Blocked by",
+          "Linked pull requests",
+          "Labels",
+          "Milestone"
+        ]
+      },
+      {
+        "name": "Implementation Queue Detailed",
+        "layout": "table",
+        "filter": "status:Ready -label:epic",
+        "groupBy": "Area",
+        "sortBy": [
+          {
+            "field": "Priority",
+            "direction": "asc"
+          },
+          {
+            "field": "Phase",
+            "direction": "asc"
+          }
+        ],
+        "visibleFields": [
+          "Title",
+          "Phase",
+          "Priority",
+          "Readiness",
+          "Area",
+          "Parent Epic",
+          "Blocked by",
+          "Linked pull requests",
+          "Labels",
+          "Milestone"
+        ],
+        "notes": [
+          "This duplicate detailed view is used when an earlier manually-created or minimally-created Implementation Queue cannot be patched in place by the REST API."
+        ]
+      },
+      {
+        "name": "VDD Research",
+        "layout": "table",
+        "filter": "label:vdd",
+        "groupBy": "Parent Epic",
+        "sortBy": [
+          {
+            "field": "Priority",
+            "direction": "asc"
+          }
+        ],
+        "visibleFields": [
+          "Title",
+          "Requirement Status",
+          "Readiness",
+          "Priority",
+          "Source Doc",
+          "Thesis Evidence",
+          "Test Target",
+          "Risk",
+          "Blocked by"
+        ]
+      },
+      {
+        "name": "Safety & Privacy",
+        "layout": "table",
+        "filter": "area:Safety",
+        "groupBy": "Readiness",
+        "sortBy": [
+          {
+            "field": "Priority",
+            "direction": "asc"
+          }
+        ],
+        "visibleFields": [
+          "Title",
+          "Risk",
+          "Test Target",
+          "Thesis Evidence",
+          "Labels",
+          "Blocked by",
+          "Blocking",
+          "Acceptance Criteria",
+          "Milestone"
         ]
       },
       {
         "name": "Quality Gates",
         "layout": "table",
-        "filter": "Area:Testing,Evaluation,Safety",
+        "filter": "label:quality-gate",
         "groupBy": "Readiness",
+        "sortBy": [
+          {
+            "field": "Priority",
+            "direction": "asc"
+          }
+        ],
         "visibleFields": [
+          "Title",
+          "Status",
           "Requirement Status",
-          "Priority",
           "Test Target",
           "Thesis Evidence",
-          "Risk"
+          "Source Doc",
+          "Linked pull requests",
+          "Labels",
+          "Blocked by"
+        ]
+      },
+      {
+        "name": "CI / Project Ops",
+        "layout": "table",
+        "filter": "label:github-actions",
+        "groupBy": "Readiness",
+        "sortBy": [
+          {
+            "field": "Priority",
+            "direction": "asc"
+          }
+        ],
+        "visibleFields": [
+          "Title",
+          "Status",
+          "Requirement Status",
+          "Source Doc",
+          "Acceptance Criteria",
+          "Linked pull requests",
+          "Labels",
+          "Blocked by"
+        ]
+      },
+      {
+        "name": "Roadmap",
+        "layout": "roadmap",
+        "filter": "-status:Done",
+        "groupBy": "Milestone",
+        "dateField": "Target Date",
+        "sliceBy": "Phase",
+        "visibleFields": [
+          "Milestone",
+          "Phase",
+          "Priority",
+          "Requirement Status",
+          "Status",
+          "Readiness",
+          "Thesis Evidence"
         ]
       }
     ]
@@ -477,6 +899,12 @@
     {
       "key": "spike-vdd-advisor-open-questions",
       "parentKey": "epic-vdd-research-framing",
+      "blockedByKeys": [
+        "adr-vdd-terminology-and-stance",
+        "req-vdd-independent-verification-agent",
+        "req-vdd-spiral-requirements-control",
+        "req-vdd-student-professional-modes"
+      ],
       "kind": "issue",
       "title": "Spike: Advisor Questions for VDD Scope and Metrics",
       "status": "Advisor Review",
@@ -970,6 +1398,12 @@
     {
       "key": "task-readiness-gate-definition",
       "parentKey": "epic-implementation-readiness",
+      "blockedByKeys": [
+        "adr-approval-gate-ablation-baseline",
+        "adr-workspace-boundary-no-shell",
+        "task-core-planning-schemas",
+        "task-security-threat-incident-retention"
+      ],
       "kind": "issue",
       "title": "TASK: Implementation readiness gate ve DoR/DoD tanimlansin",
       "status": "Advisor Review",
@@ -1064,6 +1498,11 @@
     {
       "key": "task-benchmark-template-evidence-matrix",
       "parentKey": "epic-implementation-readiness",
+      "blockedByKeys": [
+        "adr-approval-gate-ablation-baseline",
+        "task-core-planning-schemas",
+        "adr-prompt-model-versioning"
+      ],
       "kind": "issue",
       "title": "TASK: Benchmark task template ve evidence matrix hazirlansin",
       "status": "Advisor Review",
@@ -1096,6 +1535,20 @@
     {
       "key": "task-faz1-p0-ready-review",
       "parentKey": "epic-implementation-readiness",
+      "blockedByKeys": [
+        "adr-approval-gate-ablation-baseline",
+        "adr-electron-monaco-shell",
+        "adr-manual-model-selection",
+        "adr-node-runtime-target",
+        "adr-workspace-boundary-no-shell",
+        "task-benchmark-template-evidence-matrix",
+        "task-readiness-gate-definition",
+        "task-core-planning-schemas",
+        "task-devops-quality-gates-baseline",
+        "task-reproducible-dev-environment",
+        "task-security-threat-incident-retention",
+        "task-github-project-ops-templates-labels"
+      ],
       "kind": "issue",
       "title": "TASK: Faz 1 P0 kartlari advisor review sonrasi Ready kabul edilsin",
       "status": "Advisor Review",
@@ -1126,6 +1579,11 @@
     {
       "key": "task-devops-quality-gates-baseline",
       "parentKey": "epic-implementation-readiness",
+      "blockedByKeys": [
+        "adr-node-runtime-target",
+        "task-doc-diagram-validation-ci",
+        "task-reproducible-dev-environment"
+      ],
       "kind": "issue",
       "title": "TASK: Pre-implementation CI and quality gates baseline hazir olsun",
       "status": "Advisor Review",
@@ -1161,6 +1619,9 @@
     {
       "key": "task-reproducible-dev-environment",
       "parentKey": "epic-implementation-readiness",
+      "blockedByKeys": [
+        "adr-node-runtime-target"
+      ],
       "kind": "issue",
       "title": "TASK: Reproducible development environment baseline hazir olsun",
       "status": "Advisor Review",
@@ -1269,6 +1730,10 @@
     {
       "key": "adr-prompt-model-versioning",
       "parentKey": "epic-implementation-readiness",
+      "blockedByKeys": [
+        "adr-manual-model-selection",
+        "task-core-planning-schemas"
+      ],
       "kind": "issue",
       "title": "ADR: Prompt ve model versioning stratejisi sabitlensin",
       "status": "Advisor Review",
@@ -1303,6 +1768,10 @@
     {
       "key": "task-accessibility-quality-plan",
       "parentKey": "epic-implementation-readiness",
+      "blockedByKeys": [
+        "adr-electron-monaco-shell",
+        "task-devops-quality-gates-baseline"
+      ],
       "kind": "issue",
       "title": "TASK: Accessibility plan quality gate olarak hazir olsun",
       "status": "Advisor Review",
@@ -1422,6 +1891,12 @@
     {
       "key": "req-editor-shell",
       "parentKey": "epic-editor-foundation",
+      "blockedByKeys": [
+        "adr-electron-monaco-shell",
+        "adr-node-runtime-target",
+        "task-devops-quality-gates-baseline",
+        "task-reproducible-dev-environment"
+      ],
       "kind": "issue",
       "title": "REQ: Electron + Monaco tabanli editor kabugu kurulmalı",
       "status": "Draft",
@@ -1452,6 +1927,10 @@
     {
       "key": "req-editor-file-management",
       "parentKey": "epic-editor-foundation",
+      "blockedByKeys": [
+        "req-editor-shell",
+        "adr-workspace-boundary-no-shell"
+      ],
       "kind": "issue",
       "title": "REQ: Proje klasoru acma, dosya agaci, dosya ac-kaydet ve 5 sekme desteklensin",
       "status": "Draft",
@@ -1481,6 +1960,9 @@
     {
       "key": "req-editor-status-bar",
       "parentKey": "epic-editor-foundation",
+      "blockedByKeys": [
+        "req-editor-shell"
+      ],
       "kind": "issue",
       "title": "REQ: Durum cubugu aktif dosya ve ajan durumunu gostermeli",
       "status": "Draft",
@@ -1510,6 +1992,13 @@
     {
       "key": "req-editor-onboarding-configuration",
       "parentKey": "epic-editor-foundation",
+      "blockedByKeys": [
+        "req-editor-shell",
+        "adr-manual-model-selection",
+        "adr-workspace-boundary-no-shell",
+        "task-security-threat-incident-retention",
+        "task-accessibility-quality-plan"
+      ],
       "kind": "issue",
       "title": "REQ: Ilk acilis onboarding ve guvenli konfigurasyon akisi desteklenmeli",
       "status": "Draft",
@@ -1543,6 +2032,11 @@
     {
       "key": "req-context-always-on",
       "parentKey": "epic-context-retrieval",
+      "blockedByKeys": [
+        "req-editor-shell",
+        "adr-workspace-boundary-no-shell",
+        "task-core-planning-schemas"
+      ],
       "kind": "issue",
       "title": "REQ: Always-on context aktif dosya, ilgili sembol ve proje agacini icermeli",
       "status": "Draft",
@@ -1571,6 +2065,9 @@
     {
       "key": "req-context-on-demand",
       "parentKey": "epic-context-retrieval",
+      "blockedByKeys": [
+        "req-context-index-and-ignore"
+      ],
       "kind": "issue",
       "title": "REQ: On-demand retrieval import-export, sembol arama ve benzer parca bulmayi desteklemeli",
       "status": "Draft",
@@ -1600,6 +2097,11 @@
     {
       "key": "req-context-index-and-ignore",
       "parentKey": "epic-context-retrieval",
+      "blockedByKeys": [
+        "req-context-always-on",
+        "adr-workspace-boundary-no-shell",
+        "task-security-threat-incident-retention"
+      ],
       "kind": "issue",
       "title": "REQ: Arka planda embedding index guncellensin ve .agentignore ile gizli dosyalar dislansin",
       "status": "Draft",
@@ -1631,6 +2133,11 @@
     {
       "key": "req-agent-chat",
       "parentKey": "epic-agent-loop",
+      "blockedByKeys": [
+        "req-editor-shell",
+        "adr-manual-model-selection",
+        "adr-prompt-model-versioning"
+      ],
       "kind": "issue",
       "title": "REQ: Kullanici tetiklemeli sohbet paneli gorev girisi saglamali",
       "status": "Draft",
@@ -1660,6 +2167,11 @@
     {
       "key": "req-agent-plan-first",
       "parentKey": "epic-agent-loop",
+      "blockedByKeys": [
+        "req-agent-chat",
+        "task-core-planning-schemas",
+        "req-vdd-independent-verification-agent"
+      ],
       "kind": "issue",
       "title": "REQ: Ajan plani dosya bazli degisiklik ozeti ve gerekce ile sunmali",
       "status": "Draft",
@@ -1689,6 +2201,11 @@
     {
       "key": "req-agent-tool-whitelist",
       "parentKey": "epic-agent-loop",
+      "blockedByKeys": [
+        "req-agent-plan-first",
+        "adr-workspace-boundary-no-shell",
+        "task-security-threat-incident-retention"
+      ],
       "kind": "issue",
       "title": "REQ: Ajan araclari whitelist yaklasimiyla sinirlansin ve explain-only akis desteklensin",
       "status": "Draft",
@@ -1719,6 +2236,9 @@
     {
       "key": "req-diff-views",
       "parentKey": "epic-diff-approval",
+      "blockedByKeys": [
+        "req-editor-shell"
+      ],
       "kind": "issue",
       "title": "REQ: Diff ekrani side-by-side ve unified gorunum sunmali",
       "status": "Draft",
@@ -1747,6 +2267,11 @@
     {
       "key": "req-diff-selective-approval",
       "parentKey": "epic-diff-approval",
+      "blockedByKeys": [
+        "req-agent-plan-first",
+        "req-diff-views",
+        "adr-approval-gate-ablation-baseline"
+      ],
       "kind": "issue",
       "title": "REQ: Cok dosyali degisikliklerde secmeli onay desteklenmeli",
       "status": "Draft",
@@ -1776,6 +2301,10 @@
     {
       "key": "req-diff-atomic-rollback",
       "parentKey": "epic-diff-approval",
+      "blockedByKeys": [
+        "req-diff-selective-approval",
+        "adr-workspace-boundary-no-shell"
+      ],
       "kind": "issue",
       "title": "REQ: Dosya uygulama atomik olmali ve son 10 degisiklik geri alinabilmeli",
       "status": "Draft",
@@ -1805,6 +2334,10 @@
     {
       "key": "req-safety-sandbox",
       "parentKey": "epic-safety-privacy",
+      "blockedByKeys": [
+        "adr-workspace-boundary-no-shell",
+        "task-security-threat-incident-retention"
+      ],
       "kind": "issue",
       "title": "REQ: Workspace boundary + path normalization yalnizca proje dizini icinde calismali",
       "status": "Draft",
@@ -1834,6 +2367,10 @@
     {
       "key": "req-safety-protected-files",
       "parentKey": "epic-safety-privacy",
+      "blockedByKeys": [
+        "req-safety-sandbox",
+        "task-security-threat-incident-retention"
+      ],
       "kind": "issue",
       "title": "REQ: Protected file kurallari gizli anahtar dosyalarinda indeksleme ve yazmayi engellemeli",
       "status": "Draft",
@@ -1863,6 +2400,11 @@
     {
       "key": "req-safety-audit-log",
       "parentKey": "epic-safety-privacy",
+      "blockedByKeys": [
+        "task-core-planning-schemas",
+        "task-security-threat-incident-retention",
+        "req-safety-reactive-warnings"
+      ],
       "kind": "issue",
       "title": "REQ: Audit log okuma, retrieval, yazma, onay ve rollback kararlarini kaydetmeli",
       "status": "Draft",
@@ -1893,6 +2435,10 @@
     {
       "key": "risk-safety-readonly-fallback",
       "parentKey": "epic-safety-privacy",
+      "blockedByKeys": [
+        "req-safety-reactive-warnings",
+        "req-agent-tool-whitelist"
+      ],
       "kind": "issue",
       "title": "Risk: Kalite veya guvenlik esikleri bozulursa ajan explain-only moda dusurulebilmeli",
       "status": "Draft",
@@ -1922,6 +2468,10 @@
     {
       "key": "req-ux-why-explanation",
       "parentKey": "epic-ux-interaction",
+      "blockedByKeys": [
+        "req-agent-plan-first",
+        "req-diff-selective-approval"
+      ],
       "kind": "issue",
       "title": "REQ: Kullanici diff ekraninda neden aciklamasini gorebilmeli",
       "status": "Draft",
@@ -1950,6 +2500,10 @@
     {
       "key": "req-ux-control-points",
       "parentKey": "epic-ux-interaction",
+      "blockedByKeys": [
+        "req-diff-selective-approval",
+        "req-diff-atomic-rollback"
+      ],
       "kind": "issue",
       "title": "REQ: Her kritik adimda kontrol noktalari approve-reject-edit-undo olarak sunulmali",
       "status": "Draft",
@@ -1978,6 +2532,9 @@
     {
       "key": "req-ux-proactive-guards",
       "parentKey": "epic-ux-interaction",
+      "blockedByKeys": [
+        "req-safety-reactive-warnings"
+      ],
       "kind": "issue",
       "title": "REQ: Reactive safety warnings yalnizca apply oncesi tetiklensin (background analiz MVP disi)",
       "status": "Draft",
@@ -2012,6 +2569,10 @@
     {
       "key": "req-safety-reactive-warnings",
       "parentKey": "epic-safety-privacy",
+      "blockedByKeys": [
+        "req-safety-protected-files",
+        "task-core-planning-schemas"
+      ],
       "kind": "issue",
       "title": "REQ: Apply oncesi reactive safety check 4 trigger'i zorunlu calistirmali",
       "status": "Draft",
@@ -2044,6 +2605,11 @@
     {
       "key": "req-model-provider-abstraction",
       "parentKey": "epic-model-cost",
+      "blockedByKeys": [
+        "adr-manual-model-selection",
+        "adr-node-runtime-target",
+        "adr-prompt-model-versioning"
+      ],
       "kind": "issue",
       "title": "REQ: Bir bulut ve bir yerel model saglayicisi ortak adaptor katmaniyla desteklenmeli",
       "status": "Draft",
@@ -2074,6 +2640,10 @@
     {
       "key": "req-model-user-selection",
       "parentKey": "epic-model-cost",
+      "blockedByKeys": [
+        "req-model-provider-abstraction",
+        "req-editor-onboarding-configuration"
+      ],
       "kind": "issue",
       "title": "REQ: Model secimi kullanici tercihine birakilmali",
       "status": "Draft",
@@ -2105,6 +2675,10 @@
     {
       "key": "req-model-cost-metrics",
       "parentKey": "epic-model-cost",
+      "blockedByKeys": [
+        "req-model-provider-abstraction",
+        "req-evaluation-metrics"
+      ],
       "kind": "issue",
       "title": "REQ: Gecikme ve maliyet yerel-bulut ayrimiyla raporlanmali",
       "status": "Draft",
@@ -2137,6 +2711,9 @@
     {
       "key": "risk-model-local-fallback",
       "parentKey": "epic-model-cost",
+      "blockedByKeys": [
+        "req-model-provider-abstraction"
+      ],
       "kind": "issue",
       "title": "Risk: Bulut maliyeti kritikse local-only fallback plani hazir olmali",
       "status": "Draft",
@@ -2167,6 +2744,11 @@
     {
       "key": "req-test-unit",
       "parentKey": "epic-testing-evaluation",
+      "blockedByKeys": [
+        "task-devops-quality-gates-baseline",
+        "task-core-planning-schemas",
+        "adr-workspace-boundary-no-shell"
+      ],
       "kind": "issue",
       "title": "REQ: Birim testleri diff, workspace boundary, retrieval ve audit modullerini kapsamali",
       "status": "Draft",
@@ -2195,6 +2777,13 @@
     {
       "key": "req-test-integration",
       "parentKey": "epic-testing-evaluation",
+      "blockedByKeys": [
+        "req-test-unit",
+        "req-agent-plan-first",
+        "req-diff-selective-approval",
+        "req-diff-atomic-rollback",
+        "req-safety-reactive-warnings"
+      ],
       "kind": "issue",
       "title": "REQ: Entegrasyon testleri plan-diff-apply-rollback-safety akislarini dogrulamali",
       "status": "Draft",
@@ -2223,6 +2812,11 @@
     {
       "key": "req-test-e2e",
       "parentKey": "epic-testing-evaluation",
+      "blockedByKeys": [
+        "req-test-integration",
+        "req-ux-control-points",
+        "task-accessibility-quality-plan"
+      ],
       "kind": "issue",
       "title": "REQ: Uctan uca testler partial approval, safety stop ve gercek kullanici akislarini simule etmeli",
       "status": "Draft",
@@ -2251,6 +2845,11 @@
     {
       "key": "req-evaluation-benchmark",
       "parentKey": "epic-testing-evaluation",
+      "blockedByKeys": [
+        "task-benchmark-template-evidence-matrix",
+        "adr-approval-gate-ablation-baseline",
+        "req-evaluation-metrics"
+      ],
       "kind": "issue",
       "title": "REQ: Benchmark 20 gorev, ablation tasarimi (A/B/C) ile tanimlanmali",
       "status": "Draft",
@@ -2282,6 +2881,10 @@
     {
       "key": "req-evaluation-metrics",
       "parentKey": "epic-testing-evaluation",
+      "blockedByKeys": [
+        "task-benchmark-template-evidence-matrix",
+        "adr-prompt-model-versioning"
+      ],
       "kind": "issue",
       "title": "REQ: Basari, guvenlik, rollback, halusinasyon, gecikme ve guven metrikleri toplanmali",
       "status": "Draft",
@@ -2313,6 +2916,10 @@
     {
       "key": "req-thesis-phase-gates",
       "parentKey": "epic-thesis-roadmap",
+      "blockedByKeys": [
+        "task-github-project-ops-templates-labels",
+        "task-readiness-gate-definition"
+      ],
       "kind": "issue",
       "title": "REQ: Faz 1, Faz 2 ve Faz 3 cikti kapilari Project icinde izlenmeli",
       "status": "Draft",
@@ -2341,6 +2948,10 @@
     {
       "key": "req-thesis-freeze",
       "parentKey": "epic-thesis-roadmap",
+      "blockedByKeys": [
+        "task-faz1-p0-ready-review",
+        "req-evaluation-benchmark"
+      ],
       "kind": "issue",
       "title": "REQ: Degerlendirme fazi basladiktan sonra yeni ana ozellik alinmamali",
       "status": "Draft",
@@ -2369,6 +2980,11 @@
     {
       "key": "req-thesis-final-deliverables",
       "parentKey": "epic-thesis-roadmap",
+      "blockedByKeys": [
+        "req-evaluation-benchmark",
+        "req-evaluation-metrics",
+        "req-thesis-freeze"
+      ],
       "kind": "issue",
       "title": "REQ: Final teslimler demo, tez metni, sunum ve savunma paketi olarak takip edilmeli",
       "status": "Draft",

--- a/scripts/setup-requirements-github-project.ps1
+++ b/scripts/setup-requirements-github-project.ps1
@@ -63,6 +63,43 @@ function Get-Collection {
   return @($Value)
 }
 
+function Get-ViewSortFieldName {
+  param([object]$SortSpec)
+
+  if ($null -eq $SortSpec) {
+    return $null
+  }
+
+  $fieldName = Get-PropertyValue -Object $SortSpec -Name 'field'
+  if (-not [string]::IsNullOrWhiteSpace([string]$fieldName)) {
+    return [string]$fieldName
+  }
+
+  return [string]$SortSpec
+}
+
+function Get-ViewSortDirection {
+  param([object]$SortSpec)
+
+  $direction = Get-PropertyValue -Object $SortSpec -Name 'direction'
+  if ([string]::IsNullOrWhiteSpace([string]$direction)) {
+    return 'asc'
+  }
+
+  $normalized = ([string]$direction).ToLowerInvariant()
+  if ($normalized -notin @('asc', 'desc')) {
+    throw "Unsupported view sort direction: $direction"
+  }
+
+  return $normalized
+}
+
+function Get-ProjectFilterAlias {
+  param([string]$FieldName)
+
+  return $FieldName.Trim().ToLowerInvariant() -replace '\s+', '-'
+}
+
 function Invoke-Gh {
   param(
     [Parameter(Mandatory = $true)]
@@ -214,15 +251,39 @@ function Assert-Spec {
     'Risk',
     'Test Target',
     'Thesis Evidence',
-    'Readiness'
+    'Readiness',
+    'Blocked by',
+    'Blocking',
+    'Dependency Count',
+    'Blocking Count',
+    'Child Issue Count'
+  )
+
+  $standardProjectFields = @(
+    'Title',
+    'Assignees',
+    'Status',
+    'Labels',
+    'Linked pull requests',
+    'Milestone',
+    'Repository',
+    'Reviewers',
+    'Parent issue',
+    'Sub-issues progress'
   )
 
   $projectFieldNames = @{}
+  $knownProjectFieldNames = @{}
+  foreach ($fieldName in $standardProjectFields) {
+    $knownProjectFieldNames[$fieldName] = $true
+  }
+
   $singleSelectOptionsByField = @{}
   foreach ($field in $Spec.project.fields) {
     Assert-TextValue -Value $field.name -Message 'Project field without a name detected.'
     Assert-TextValue -Value $field.dataType -Message "Project field $($field.name) is missing dataType."
     $projectFieldNames[$field.name] = $true
+    $knownProjectFieldNames[$field.name] = $true
 
     if ($field.dataType -eq 'SINGLE_SELECT') {
       $options = @{}
@@ -245,32 +306,78 @@ function Assert-Spec {
     }
   }
 
+  $knownFilterFields = @{}
+  foreach ($fieldName in $knownProjectFieldNames.Keys) {
+    $knownFilterFields[$fieldName.ToLowerInvariant()] = $true
+    $knownFilterFields[(Get-ProjectFilterAlias -FieldName $fieldName)] = $true
+  }
+
+  foreach ($alias in @('label', 'labels', 'assignee', 'assignees', 'repo', 'repository', 'milestone', 'is', 'no', 'type', 'reviewer', 'linked')) {
+    $knownFilterFields[$alias] = $true
+  }
+
+  $milestoneTitles = @{}
+  $milestonePhases = @{}
+  foreach ($milestone in (Get-Collection (Get-PropertyValue -Object $Spec.project -Name 'milestones'))) {
+    Assert-TextValue -Value $milestone.title -Message 'Project milestone without a title detected.'
+    Assert-TextValue -Value $milestone.phase -Message "Project milestone $($milestone.title) is missing phase."
+
+    if (-not $singleSelectOptionsByField['Phase'].ContainsKey($milestone.phase)) {
+      throw "Project milestone $($milestone.title) uses invalid phase: $($milestone.phase)"
+    }
+
+    if ($milestoneTitles.ContainsKey($milestone.title)) {
+      throw "Duplicate project milestone title detected: $($milestone.title)"
+    }
+
+    if ($milestonePhases.ContainsKey($milestone.phase)) {
+      throw "Duplicate project milestone phase mapping detected for $($milestone.phase). Keep exactly one milestone per phase."
+    }
+
+    $milestoneTitles[$milestone.title] = $true
+    $milestonePhases[$milestone.phase] = $true
+  }
+
   foreach ($view in (Get-Collection $Spec.project.views)) {
     Assert-TextValue -Value $view.name -Message 'Project view without a name detected.'
     Assert-TextValue -Value $view.layout -Message "Project view $($view.name) is missing layout."
 
     foreach ($fieldName in (Get-Collection (Get-PropertyValue -Object $view -Name 'visibleFields'))) {
-      if (-not $projectFieldNames.ContainsKey($fieldName) -and $fieldName -ne 'Status') {
+      if (-not $knownProjectFieldNames.ContainsKey($fieldName)) {
         throw "Project view $($view.name) references unknown visible field: $fieldName"
       }
     }
 
-    foreach ($fieldName in (Get-Collection (Get-PropertyValue -Object $view -Name 'sortBy'))) {
-      if (-not $projectFieldNames.ContainsKey($fieldName) -and $fieldName -ne 'Status') {
+    foreach ($sortSpec in (Get-Collection (Get-PropertyValue -Object $view -Name 'sortBy'))) {
+      $fieldName = Get-ViewSortFieldName -SortSpec $sortSpec
+      if (-not $knownProjectFieldNames.ContainsKey($fieldName)) {
         throw "Project view $($view.name) references unknown sort field: $fieldName"
+      }
+
+      $null = Get-ViewSortDirection -SortSpec $sortSpec
+    }
+
+    foreach ($viewFieldProperty in @('groupBy', 'columnBy', 'swimlanes', 'sliceBy', 'dateField')) {
+      $fieldName = Get-PropertyValue -Object $view -Name $viewFieldProperty
+      if (-not [string]::IsNullOrWhiteSpace([string]$fieldName) -and -not $knownProjectFieldNames.ContainsKey($fieldName)) {
+        throw "Project view $($view.name) references unknown ${viewFieldProperty} field: $fieldName"
       }
     }
 
-    $groupBy = Get-PropertyValue -Object $view -Name 'groupBy'
-    if (-not [string]::IsNullOrWhiteSpace([string]$groupBy) -and -not $projectFieldNames.ContainsKey($groupBy) -and $groupBy -ne 'Status') {
-      throw "Project view $($view.name) references unknown groupBy field: $groupBy"
+    foreach ($fieldName in (Get-Collection (Get-PropertyValue -Object $view -Name 'fieldSums'))) {
+      if (-not $knownProjectFieldNames.ContainsKey($fieldName)) {
+        throw "Project view $($view.name) references unknown fieldSums field: $fieldName"
+      }
     }
 
     $filter = Get-PropertyValue -Object $view -Name 'filter'
-    if (-not [string]::IsNullOrWhiteSpace([string]$filter) -and $filter -match '^(?<field>[^:]+):') {
-      $filterField = $Matches.field.Trim()
-      if (-not $projectFieldNames.ContainsKey($filterField) -and $filterField -ne 'Status') {
-        throw "Project view $($view.name) references unknown filter field: $filterField"
+    if (-not [string]::IsNullOrWhiteSpace([string]$filter)) {
+      $filterMatches = [regex]::Matches([string]$filter, '(?<!\S)-?(?<field>[A-Za-z][A-Za-z0-9 -]*):')
+      foreach ($filterMatch in $filterMatches) {
+        $filterField = $filterMatch.Groups['field'].Value.Trim().ToLowerInvariant()
+        if (-not $knownFilterFields.ContainsKey($filterField)) {
+          throw "Project view $($view.name) references unknown filter field: $filterField"
+        }
       }
     }
   }
@@ -351,6 +458,11 @@ function Assert-Spec {
       }
     }
 
+    $explicitMilestone = Get-PropertyValue -Object $issue -Name 'milestone'
+    if (-not [string]::IsNullOrWhiteSpace([string]$explicitMilestone) -and -not $milestoneTitles.ContainsKey($explicitMilestone)) {
+      throw "Issue $($issue.key) references unknown milestone: $explicitMilestone"
+    }
+
     $targetDate = Get-PropertyValue -Object $issue -Name 'targetDate'
     if (-not [string]::IsNullOrWhiteSpace([string]$targetDate)) {
       try {
@@ -372,6 +484,18 @@ function Assert-Spec {
 
     if ($issue.kind -eq 'issue' -and -not $epicKeys.ContainsKey($issue.parentKey)) {
       throw "Child issue $($issue.key) points to unknown epic key $($issue.parentKey)."
+    }
+
+    foreach ($blockedByKey in (Get-Collection (Get-PropertyValue -Object $issue -Name 'blockedByKeys'))) {
+      Assert-TextValue -Value $blockedByKey -Message "Issue $($issue.key) has an empty blockedByKeys item."
+
+      if (-not $seenKeys.ContainsKey($blockedByKey)) {
+        throw "Issue $($issue.key) is blocked by unknown issue key $blockedByKey."
+      }
+
+      if ($blockedByKey -eq $issue.key) {
+        throw "Issue $($issue.key) cannot block itself."
+      }
     }
   }
 }
@@ -560,6 +684,7 @@ query($owner: String!, $number: Int!) {
             __typename
             ... on ProjectV2FieldCommon {
               id
+              databaseId
               name
               dataType
             }
@@ -569,6 +694,16 @@ query($owner: String!, $number: Int!) {
                 name
               }
             }
+          }
+        }
+        views(first: 100) {
+          nodes {
+            id
+            fullDatabaseId
+            name
+            number
+            layout
+            filter
           }
         }
       }
@@ -582,6 +717,7 @@ query($owner: String!, $number: Int!) {
             __typename
             ... on ProjectV2FieldCommon {
               id
+              databaseId
               name
               dataType
             }
@@ -591,6 +727,16 @@ query($owner: String!, $number: Int!) {
                 name
               }
             }
+          }
+        }
+        views(first: 100) {
+          nodes {
+            id
+            fullDatabaseId
+            name
+            number
+            layout
+            filter
           }
         }
       }
@@ -627,6 +773,7 @@ function Get-FieldMap {
 
     $fieldMap[(Get-PropertyValue -Object $field -Name 'name')] = [pscustomobject]@{
       Id = Get-PropertyValue -Object $field -Name 'id'
+      DatabaseId = Get-PropertyValue -Object $field -Name 'databaseId'
       DataType = Get-PropertyValue -Object $field -Name 'dataType'
       Options = $options
     }
@@ -638,14 +785,223 @@ function Get-FieldMap {
 function Get-ExistingIssuesByTitle {
   param([string]$RepoFullName)
 
-  $issues = Get-Collection (Invoke-Gh -Arguments @('issue', 'list', '-R', $RepoFullName, '--state', 'all', '--limit', '500', '--json', 'number,title,url') -AsJson)
+  $issues = Get-Collection (Invoke-Gh -Arguments @('issue', 'list', '-R', $RepoFullName, '--state', 'open', '--limit', '500', '--json', 'number,title,url') -AsJson)
   $map = @{}
 
   foreach ($issue in $issues) {
+    if ($map.ContainsKey($issue.title)) {
+      throw "Duplicate open issue title detected in ${RepoFullName}: $($issue.title). Remove or rename the duplicate before rerunning setup."
+    }
+
     $map[$issue.title] = $issue
   }
 
   return $map
+}
+
+function Set-RepositoryMilestones {
+  param(
+    [object]$Spec,
+    [string]$RepoFullName
+  )
+
+  $milestoneSpec = Get-PropertyValue -Object $Spec.project -Name 'milestones'
+  if ($null -eq $milestoneSpec) { return @{} }
+
+  $existing = Get-Collection (Invoke-Gh -Arguments @('api', "repos/$RepoFullName/milestones?state=all", '--paginate') -AsJson)
+  $byTitle = @{}
+  foreach ($m in $existing) { $byTitle[$m.title] = $m }
+
+  $resolved = @{}
+  foreach ($m in $milestoneSpec) {
+    if ($byTitle.ContainsKey($m.title)) {
+      $existingMilestone = $byTitle[$m.title]
+      if ($existingMilestone.state -ne 'open') {
+        Write-Detail "Reopening milestone: $($m.title) (#$($existingMilestone.number))"
+        $existingMilestone = Invoke-Gh -Arguments @('api', '-X', 'PATCH', "repos/$RepoFullName/milestones/$($existingMilestone.number)", '-f', 'state=open') -AsJson
+      } else {
+        Write-Detail "Milestone exists: $($m.title) (#$($existingMilestone.number))"
+      }
+
+      $resolved[$m.title] = [int]$existingMilestone.number
+      continue
+    }
+
+    Write-Detail "Creating milestone: $($m.title)"
+    $args = @('api', "repos/$RepoFullName/milestones", '-f', "title=$($m.title)", '-f', 'state=open')
+    $description = Get-PropertyValue -Object $m -Name 'description'
+    if (-not [string]::IsNullOrWhiteSpace($description)) {
+      $args += @('-f', "description=$description")
+    }
+    $created = Invoke-Gh -Arguments $args -AsJson
+    $resolved[$m.title] = [int]$created.number
+  }
+
+  return $resolved
+}
+
+function Set-IssueMilestone {
+  param(
+    [string]$RepoFullName,
+    [int]$IssueNumber,
+    [int]$MilestoneNumber
+  )
+
+  if ($MilestoneNumber -le 0) { return }
+  $null = Invoke-Gh -Arguments @('api', '-X', 'PATCH', "repos/$RepoFullName/issues/$IssueNumber", '-F', "milestone=$MilestoneNumber")
+}
+
+function Resolve-MilestoneForIssue {
+  param(
+    [object]$IssueDefinition,
+    [object]$Spec,
+    [hashtable]$MilestonesByTitle
+  )
+
+  $milestoneSpec = Get-PropertyValue -Object $Spec.project -Name 'milestones'
+  if ($null -eq $milestoneSpec) { return 0 }
+
+  $explicit = Get-PropertyValue -Object $IssueDefinition -Name 'milestone'
+  if (-not [string]::IsNullOrWhiteSpace($explicit) -and $MilestonesByTitle.ContainsKey($explicit)) {
+    return [int]$MilestonesByTitle[$explicit]
+  }
+
+  $phase = Get-PropertyValue -Object $IssueDefinition -Name 'phase'
+  foreach ($m in $milestoneSpec) {
+    $phaseLink = Get-PropertyValue -Object $m -Name 'phase'
+    if ($phaseLink -and $phaseLink -eq $phase -and $MilestonesByTitle.ContainsKey($m.title)) {
+      return [int]$MilestonesByTitle[$m.title]
+    }
+  }
+
+  return 0
+}
+
+function Get-IssueNodeId {
+  param(
+    [string]$RepoOwner,
+    [string]$RepoName,
+    [int]$IssueNumber
+  )
+
+  $query = 'query($owner:String!,$repo:String!,$n:Int!){repository(owner:$owner,name:$repo){issue(number:$n){id}}}'
+  $response = Invoke-GhGraphQL -Query $query -Variables @{ owner = $RepoOwner; repo = $RepoName; n = $IssueNumber }
+  $issue = Get-PropertyValue -Object (Get-PropertyValue -Object $response.data -Name 'repository') -Name 'issue'
+  return Get-PropertyValue -Object $issue -Name 'id'
+}
+
+function Get-SubIssueNumbers {
+  param(
+    [string]$RepoOwner,
+    [string]$RepoName,
+    [int]$IssueNumber
+  )
+
+  $query = 'query($owner:String!,$repo:String!,$n:Int!){repository(owner:$owner,name:$repo){issue(number:$n){subIssues(first:100){nodes{number}}}}}'
+  $response = Invoke-GhGraphQL -Query $query -Variables @{ owner = $RepoOwner; repo = $RepoName; n = $IssueNumber }
+  $issue = Get-PropertyValue -Object (Get-PropertyValue -Object $response.data -Name 'repository') -Name 'issue'
+  $subIssues = Get-PropertyValue -Object $issue -Name 'subIssues'
+  $nodes = Get-Collection (Get-PropertyValue -Object $subIssues -Name 'nodes')
+  $numbers = @()
+  foreach ($node in $nodes) { $numbers += [int](Get-PropertyValue -Object $node -Name 'number') }
+  return $numbers
+}
+
+function Set-NativeSubIssueLink {
+  param(
+    [string]$RepoOwner,
+    [string]$RepoName,
+    [int]$ParentIssueNumber,
+    [int]$ChildIssueNumber
+  )
+
+  $existing = Get-SubIssueNumbers -RepoOwner $RepoOwner -RepoName $RepoName -IssueNumber $ParentIssueNumber
+  if ($existing -contains $ChildIssueNumber) {
+    return
+  }
+
+  $parentId = Get-IssueNodeId -RepoOwner $RepoOwner -RepoName $RepoName -IssueNumber $ParentIssueNumber
+  $childId  = Get-IssueNodeId -RepoOwner $RepoOwner -RepoName $RepoName -IssueNumber $ChildIssueNumber
+  if ([string]::IsNullOrWhiteSpace($parentId) -or [string]::IsNullOrWhiteSpace($childId)) {
+    Write-Warning "Sub-issue link skipped (#$ChildIssueNumber -> #$ParentIssueNumber): missing node IDs"
+    return
+  }
+
+  $mutation = 'mutation($p:ID!,$c:ID!){addSubIssue(input:{issueId:$p,subIssueId:$c}){issue{number}subIssue{number}}}'
+  try {
+    $null = Invoke-GhGraphQL -Query $mutation -Variables @{ p = $parentId; c = $childId }
+    Write-Detail "Linked sub-issue: #$ChildIssueNumber -> #$ParentIssueNumber"
+  } catch {
+    if ($_.Exception.Message -match 'already a sub|already exists') {
+      return
+    }
+    Write-Warning "Sub-issue link failed (#$ChildIssueNumber -> #$ParentIssueNumber): $($_.Exception.Message)"
+  }
+}
+
+function Get-BlockedByIssueNumbers {
+  param(
+    [string]$RepoFullName,
+    [int]$IssueNumber
+  )
+
+  $issues = Get-Collection (Invoke-Gh -Arguments @('api', "repos/$RepoFullName/issues/$IssueNumber/dependencies/blocked_by", '--paginate') -AsJson)
+  $numbers = @()
+  foreach ($issue in $issues) {
+    $numbers += [int](Get-PropertyValue -Object $issue -Name 'number')
+  }
+
+  return $numbers
+}
+
+function Get-IssueRestId {
+  param(
+    [string]$RepoFullName,
+    [int]$IssueNumber
+  )
+
+  $issue = Invoke-Gh -Arguments @('api', "repos/$RepoFullName/issues/$IssueNumber") -AsJson
+  return [int](Get-PropertyValue -Object $issue -Name 'id')
+}
+
+function Set-IssueBlockedByDependency {
+  param(
+    [string]$RepoFullName,
+    [int]$IssueNumber,
+    [int]$BlockingIssueNumber
+  )
+
+  $existing = Get-BlockedByIssueNumbers -RepoFullName $RepoFullName -IssueNumber $IssueNumber
+  if ($existing -contains $BlockingIssueNumber) {
+    return
+  }
+
+  $blockingIssueId = Get-IssueRestId -RepoFullName $RepoFullName -IssueNumber $BlockingIssueNumber
+  if ($blockingIssueId -le 0) {
+    Write-Warning "Dependency link skipped (#$IssueNumber blocked by #$BlockingIssueNumber): missing blocking issue REST id"
+    return
+  }
+
+  try {
+    $null = Invoke-Gh -Arguments @(
+      'api',
+      '-X',
+      'POST',
+      "repos/$RepoFullName/issues/$IssueNumber/dependencies/blocked_by",
+      '-H',
+      'Accept: application/vnd.github+json',
+      '-H',
+      'X-GitHub-Api-Version: 2026-03-10',
+      '-F',
+      "issue_id=$blockingIssueId"
+    )
+    Write-Detail "Linked dependency: #$IssueNumber blocked by #$BlockingIssueNumber"
+  } catch {
+    if ($_.Exception.Message -match 'already|Validation failed') {
+      return
+    }
+    Write-Warning "Dependency link failed (#$IssueNumber blocked by #$BlockingIssueNumber): $($_.Exception.Message)"
+  }
 }
 
 function Get-IssueNumberFromUrl {
@@ -749,6 +1105,40 @@ function Set-Issue {
   } finally {
     Remove-Item -LiteralPath $tempFile.FullName -ErrorAction SilentlyContinue
   }
+}
+
+function Set-IssueLabels {
+  param(
+    [object]$IssueDefinition,
+    [object]$Issue,
+    [string]$RepoFullName
+  )
+
+  $desiredLabels = @(Get-Collection (Get-PropertyValue -Object $IssueDefinition -Name 'labels'))
+  if ($desiredLabels.Count -lt 1) { return }
+
+  $current = Invoke-Gh -Arguments @('issue', 'view', ([string]$Issue.number), '-R', $RepoFullName, '--json', 'labels') -AsJson
+  $currentLabels = @{}
+  foreach ($label in (Get-Collection (Get-PropertyValue -Object $current -Name 'labels'))) {
+    $currentLabels[(Get-PropertyValue -Object $label -Name 'name')] = $true
+  }
+
+  $missing = @()
+  foreach ($labelName in $desiredLabels) {
+    if (-not $currentLabels.ContainsKey($labelName)) {
+      $missing += $labelName
+    }
+  }
+
+  if ($missing.Count -lt 1) { return }
+
+  $arguments = @('issue', 'edit', ([string]$Issue.number), '-R', $RepoFullName)
+  foreach ($labelName in $missing) {
+    $arguments += @('--add-label', $labelName)
+  }
+
+  $null = Invoke-Gh -Arguments $arguments
+  Write-Detail "Added missing labels to #$($Issue.number): $($missing -join ', ')"
 }
 
 function Get-ProjectItemIdForIssue {
@@ -877,6 +1267,9 @@ function Set-ProjectFieldValue {
     'DATE' {
       $arguments += @('--date', $Value)
     }
+    'NUMBER' {
+      $arguments += @('--number', $Value)
+    }
     default {
       $arguments += @('--text', $Value)
     }
@@ -897,6 +1290,28 @@ function Set-ProjectFieldValueIfPresent {
   if ($FieldMap.ContainsKey($FieldName)) {
     Set-ProjectFieldValue -ProjectId $ProjectId -ItemId $ItemId -FieldMap $FieldMap -FieldName $FieldName -Value $Value
   }
+}
+
+function Clear-ProjectFieldValueIfPresent {
+  param(
+    [string]$ProjectId,
+    [string]$ItemId,
+    [hashtable]$FieldMap,
+    [string]$FieldName
+  )
+
+  if (-not $FieldMap.ContainsKey($FieldName)) {
+    return
+  }
+
+  $field = $FieldMap[$FieldName]
+  $null = Invoke-Gh -Arguments @(
+    'project', 'item-edit',
+    '--id', $ItemId,
+    '--project-id', $ProjectId,
+    '--field-id', $field.Id,
+    '--clear'
+  )
 }
 
 function Get-WorkflowStatus {
@@ -1052,11 +1467,198 @@ function Get-ThesisEvidence {
   }
 }
 
+function New-BlockedByReverseMap {
+  param([object[]]$Issues)
+
+  $reverseMap = @{}
+  foreach ($issueDefinition in $Issues) {
+    $reverseMap[$issueDefinition.key] = @()
+  }
+
+  foreach ($issueDefinition in $Issues) {
+    foreach ($blockedByKey in (Get-Collection (Get-PropertyValue -Object $issueDefinition -Name 'blockedByKeys'))) {
+      $reverseMap[$blockedByKey] = @($reverseMap[$blockedByKey]) + $issueDefinition.key
+    }
+  }
+
+  return $reverseMap
+}
+
+function New-ChildIssueMap {
+  param([object[]]$Issues)
+
+  $childMap = @{}
+  foreach ($issueDefinition in $Issues) {
+    $childMap[$issueDefinition.key] = @()
+  }
+
+  foreach ($issueDefinition in $Issues) {
+    $parentKey = Get-PropertyValue -Object $issueDefinition -Name 'parentKey'
+    if ([string]::IsNullOrWhiteSpace([string]$parentKey)) {
+      continue
+    }
+
+    $childMap[$parentKey] = @($childMap[$parentKey]) + $issueDefinition.key
+  }
+
+  return $childMap
+}
+
+function Get-IssueReferenceText {
+  param(
+    [object[]]$Keys,
+    [hashtable]$IssueDefinitionsByKey,
+    [hashtable]$ExistingIssuesByTitle
+  )
+
+  $references = @()
+  foreach ($key in $Keys) {
+    if (-not $IssueDefinitionsByKey.ContainsKey($key)) {
+      $references += [string]$key
+      continue
+    }
+
+    $issueDefinition = $IssueDefinitionsByKey[$key]
+    $issue = $ExistingIssuesByTitle[$issueDefinition.title]
+    if ($null -ne $issue -and -not [string]::IsNullOrWhiteSpace([string]$issue.number)) {
+      $references += "#$($issue.number)"
+      continue
+    }
+
+    $references += [string]$key
+  }
+
+  return ($references | Sort-Object -Unique) -join ', '
+}
+
+function Get-ProjectViewsEndpoint {
+  param(
+    [string]$OwnerLogin,
+    [int]$ProjectNumber
+  )
+
+  $ownerData = Invoke-Gh -Arguments @('api', "users/$OwnerLogin") -AsJson
+  $ownerType = Get-PropertyValue -Object $ownerData -Name 'type'
+
+  if ($ownerType -eq 'Organization') {
+    return "/orgs/$OwnerLogin/projectsV2/$ProjectNumber/views"
+  }
+
+  $ownerId = Get-PropertyValue -Object $ownerData -Name 'id'
+  if ($null -eq $ownerId) {
+    throw "Could not resolve numeric GitHub user id for $OwnerLogin."
+  }
+
+  return "/users/$OwnerLogin/projectsV2/$ProjectNumber/views"
+}
+
+function Resolve-ProjectViewFieldDatabaseIds {
+  param(
+    [hashtable]$FieldMap,
+    [object[]]$FieldNames
+  )
+
+  $ids = @()
+  foreach ($fieldName in (Get-Collection $FieldNames)) {
+    if (-not $FieldMap.ContainsKey($fieldName)) {
+      throw "Project view references field that does not exist in the target project: $fieldName"
+    }
+
+    $databaseId = $FieldMap[$fieldName].DatabaseId
+    if ($null -eq $databaseId) {
+      throw "Project field does not expose a numeric database id for view configuration: $fieldName"
+    }
+
+    $ids += [int64]$databaseId
+  }
+
+  return @($ids)
+}
+
+function ConvertTo-ProjectViewPayload {
+  param(
+    [object]$View,
+    [hashtable]$FieldMap,
+    [switch]$Minimal
+  )
+
+  $layout = ([string]$View.layout).ToLowerInvariant()
+  $payload = [ordered]@{
+    name = $View.name
+    layout = $layout
+  }
+
+  $filter = Get-PropertyValue -Object $View -Name 'filter'
+  if (-not [string]::IsNullOrWhiteSpace([string]$filter)) {
+    $payload.filter = [string]$filter
+  }
+
+  if ($layout -ne 'roadmap') {
+    $visibleFieldIds = @(Resolve-ProjectViewFieldDatabaseIds -FieldMap $FieldMap -FieldNames (Get-PropertyValue -Object $View -Name 'visibleFields'))
+    if ($visibleFieldIds.Count -gt 0) {
+      $payload.visible_fields = $visibleFieldIds
+    }
+  }
+
+  if ($Minimal) {
+    return $payload
+  }
+
+  $groupBy = Get-PropertyValue -Object $View -Name 'groupBy'
+  $swimlanes = Get-PropertyValue -Object $View -Name 'swimlanes'
+  if (-not [string]::IsNullOrWhiteSpace([string]$groupBy)) {
+    $payload.group_by = @(Resolve-ProjectViewFieldDatabaseIds -FieldMap $FieldMap -FieldNames @($groupBy))
+  } elseif (-not [string]::IsNullOrWhiteSpace([string]$swimlanes)) {
+    $payload.group_by = @(Resolve-ProjectViewFieldDatabaseIds -FieldMap $FieldMap -FieldNames @($swimlanes))
+  }
+
+  $columnBy = Get-PropertyValue -Object $View -Name 'columnBy'
+  if (-not [string]::IsNullOrWhiteSpace([string]$columnBy)) {
+    $payload.vertical_group_by = @(Resolve-ProjectViewFieldDatabaseIds -FieldMap $FieldMap -FieldNames @($columnBy))
+  }
+
+  $sortBy = @()
+  foreach ($sortSpec in (Get-Collection (Get-PropertyValue -Object $View -Name 'sortBy'))) {
+    $sortFieldName = Get-ViewSortFieldName -SortSpec $sortSpec
+    $sortFieldIds = @(Resolve-ProjectViewFieldDatabaseIds -FieldMap $FieldMap -FieldNames @($sortFieldName))
+    if ($sortFieldIds.Count -lt 1) {
+      continue
+    }
+
+    $sortBy += ,@($sortFieldIds[0], (Get-ViewSortDirection -SortSpec $sortSpec))
+  }
+
+  if ($sortBy.Count -gt 0) {
+    $payload.sort_by = $sortBy
+  }
+
+  return $payload
+}
+
+function Invoke-ProjectViewApi {
+  param(
+    [string]$Method,
+    [string]$Endpoint,
+    [hashtable]$Payload
+  )
+
+  $payloadFile = New-TemporaryFile
+  try {
+    $payloadJson = $Payload | ConvertTo-Json -Depth 10
+    [System.IO.File]::WriteAllText($payloadFile.FullName, $payloadJson, [System.Text.UTF8Encoding]::new($false))
+    return Invoke-Gh -Arguments @('api', '-X', $Method, $Endpoint, '--input', $payloadFile.FullName) -AsJson
+  } finally {
+    Remove-Item -LiteralPath $payloadFile.FullName -ErrorAction SilentlyContinue
+  }
+}
+
 function New-ProjectViews {
   param(
     [object]$Spec,
     [string]$OwnerLogin,
-    [int]$ProjectNumber
+    [int]$ProjectNumber,
+    [object]$ProjectMetadata,
+    [hashtable]$FieldMap
   )
 
   if ($SkipViews) {
@@ -1072,34 +1674,40 @@ function New-ProjectViews {
   }
 
   try {
-    $ownerData = Invoke-Gh -Arguments @('api', "users/$OwnerLogin") -AsJson
-    $ownerId = Get-PropertyValue -Object $ownerData -Name 'id'
-    if ($null -eq $ownerId) {
-      throw "Could not resolve numeric GitHub user id for $OwnerLogin."
-    }
-
-    $existingViews = Get-Collection (Invoke-Gh -Arguments @('api', "/users/$ownerId/projects/$ProjectNumber/views") -AsJson)
+    $viewsEndpoint = Get-ProjectViewsEndpoint -OwnerLogin $OwnerLogin -ProjectNumber $ProjectNumber
+    $existingViews = Get-Collection (Get-PropertyValue -Object (Get-PropertyValue -Object $ProjectMetadata -Name 'views') -Name 'nodes')
     $existingViewNames = @{}
     foreach ($view in $existingViews) {
-      $existingViewNames[(Get-PropertyValue -Object $view -Name 'name')] = $true
+      $existingViewNames[(Get-PropertyValue -Object $view -Name 'name')] = $view
     }
 
     foreach ($view in $Spec.project.views) {
       if ($existingViewNames.ContainsKey($view.name)) {
+        $existingView = $existingViewNames[$view.name]
+        $viewNumber = Get-PropertyValue -Object $existingView -Name 'number'
+        $payload = ConvertTo-ProjectViewPayload -View $view -FieldMap $FieldMap
+        try {
+          $null = Invoke-ProjectViewApi -Method 'PATCH' -Endpoint "$viewsEndpoint/$viewNumber" -Payload $payload
+          Write-Detail "Updated project view: $($view.name)"
+        } catch {
+          Write-Warning "Project view '$($view.name)' already exists but could not be updated automatically. GitHub currently exposes stable creation support, while existing view column/group/sort updates may require the UI. Details: $($_.Exception.Message)"
+        }
+
         continue
       }
 
       Write-Detail "Creating project view: $($view.name)"
-      $payloadFile = New-TemporaryFile
       try {
-        $payload = @{
-          name = $view.name
-          layout = $view.layout
-        } | ConvertTo-Json
-        Set-Content -LiteralPath $payloadFile.FullName -Value $payload -Encoding UTF8
-        $null = Invoke-Gh -Arguments @('api', '-X', 'POST', "/users/$ownerId/projects/$ProjectNumber/views", '--input', $payloadFile.FullName)
-      } finally {
-        Remove-Item -LiteralPath $payloadFile.FullName -ErrorAction SilentlyContinue
+        $payload = ConvertTo-ProjectViewPayload -View $view -FieldMap $FieldMap
+        $null = Invoke-ProjectViewApi -Method 'POST' -Endpoint $viewsEndpoint -Payload $payload
+      } catch {
+        Write-Warning "Full project view creation payload failed for '$($view.name)'. Retrying with the stable documented payload. Details: $($_.Exception.Message)"
+        try {
+          $minimalPayload = ConvertTo-ProjectViewPayload -View $view -FieldMap $FieldMap -Minimal
+          $null = Invoke-ProjectViewApi -Method 'POST' -Endpoint $viewsEndpoint -Payload $minimalPayload
+        } catch {
+          Write-Warning "Project view '$($view.name)' could not be created automatically. Details: $($_.Exception.Message)"
+        }
       }
     }
   } catch {
@@ -1108,7 +1716,7 @@ function New-ProjectViews {
 }
 
 $specFile = Resolve-SpecPath -RequestedPath $SpecPath
-$spec = Get-Content -LiteralPath $specFile -Raw | ConvertFrom-Json
+$spec = Get-Content -LiteralPath $specFile -Raw -Encoding UTF8 | ConvertFrom-Json
 Assert-Spec -Spec $spec
 
 $repoInfo = Get-RepoInfo -RepoOverride $Repo
@@ -1133,6 +1741,9 @@ Assert-GhReady
 Write-Step 'Ensuring repository labels'
 Set-RepositoryLabels -Spec $spec -RepoFullName $repoInfo.FullName
 
+Write-Step 'Ensuring repository milestones'
+$milestonesByTitle = Set-RepositoryMilestones -Spec $spec -RepoFullName $repoInfo.FullName
+
 Write-Step 'Ensuring GitHub Project'
 $project = Get-OrCreateProject -OwnerLogin $ownerLogin -Title $projectName
 $projectNumber = [string](Get-PropertyValue -Object $project -Name 'number')
@@ -1145,7 +1756,7 @@ $projectId = Get-PropertyValue -Object $projectMetadata -Name 'id'
 $fieldMap = Get-FieldMap -ProjectMetadata $projectMetadata
 
 Write-Step 'Ensuring project views'
-New-ProjectViews -Spec $spec -OwnerLogin $ownerLogin -ProjectNumber ([int]$projectNumber)
+New-ProjectViews -Spec $spec -OwnerLogin $ownerLogin -ProjectNumber ([int]$projectNumber) -ProjectMetadata $projectMetadata -FieldMap $fieldMap
 
 Write-Step 'Ensuring issues and project items'
 $existingIssuesByTitle = Get-ExistingIssuesByTitle -RepoFullName $repoInfo.FullName
@@ -1154,6 +1765,8 @@ foreach ($issueDefinition in $spec.issues) {
   $issueDefinitionsByKey[$issueDefinition.key] = $issueDefinition
 }
 
+$itemIdsByKey = @{}
+
 $orderedIssues = @(
   $spec.issues |
     Sort-Object @{ Expression = { if ($_.kind -eq 'epic') { 0 } else { 1 } } }, title
@@ -1161,7 +1774,9 @@ $orderedIssues = @(
 
 foreach ($issueDefinition in $orderedIssues) {
   $issue = Set-Issue -IssueDefinition $issueDefinition -IssueDefinitionsByKey $issueDefinitionsByKey -ExistingIssuesByTitle $existingIssuesByTitle -RepoFullName $repoInfo.FullName
+  Set-IssueLabels -IssueDefinition $issueDefinition -Issue $issue -RepoFullName $repoInfo.FullName
   $itemId = Set-IssueInProject -OwnerLogin $ownerLogin -ProjectNumber $projectNumber -RepoOwner $repoInfo.Owner -RepoName $repoInfo.Name -Issue $issue
+  $itemIdsByKey[$issueDefinition.key] = $itemId
 
   if ($SyncWorkflowStatus) {
     Set-ProjectFieldValueIfPresent -ProjectId $projectId -ItemId $itemId -FieldMap $fieldMap -FieldName 'Status' -Value (Get-WorkflowStatus -IssueDefinition $issueDefinition)
@@ -1189,6 +1804,72 @@ foreach ($issueDefinition in $orderedIssues) {
   $targetDate = Get-PropertyValue -Object $issueDefinition -Name 'targetDate'
   if (-not [string]::IsNullOrWhiteSpace($targetDate)) {
     Set-ProjectFieldValue -ProjectId $projectId -ItemId $itemId -FieldMap $fieldMap -FieldName 'Target Date' -Value $targetDate
+  }
+
+  $milestoneNumber = Resolve-MilestoneForIssue -IssueDefinition $issueDefinition -Spec $spec -MilestonesByTitle $milestonesByTitle
+  if ($milestoneNumber -gt 0) {
+    Set-IssueMilestone -RepoFullName $repoInfo.FullName -IssueNumber $issue.number -MilestoneNumber $milestoneNumber
+  }
+}
+
+Write-Step 'Updating project dependency summary fields'
+$blockingKeysByKey = New-BlockedByReverseMap -Issues $spec.issues
+$childKeysByKey = New-ChildIssueMap -Issues $spec.issues
+foreach ($issueDefinition in $orderedIssues) {
+  if (-not $itemIdsByKey.ContainsKey($issueDefinition.key)) {
+    continue
+  }
+
+  $itemId = $itemIdsByKey[$issueDefinition.key]
+  $blockedByKeys = @(Get-Collection (Get-PropertyValue -Object $issueDefinition -Name 'blockedByKeys'))
+  $blockingKeys = @(Get-Collection $blockingKeysByKey[$issueDefinition.key])
+  $childKeys = @(Get-Collection $childKeysByKey[$issueDefinition.key])
+
+  $blockedByText = Get-IssueReferenceText -Keys $blockedByKeys -IssueDefinitionsByKey $issueDefinitionsByKey -ExistingIssuesByTitle $existingIssuesByTitle
+  $blockingText = Get-IssueReferenceText -Keys $blockingKeys -IssueDefinitionsByKey $issueDefinitionsByKey -ExistingIssuesByTitle $existingIssuesByTitle
+
+  if ([string]::IsNullOrWhiteSpace($blockedByText)) {
+    Clear-ProjectFieldValueIfPresent -ProjectId $projectId -ItemId $itemId -FieldMap $fieldMap -FieldName 'Blocked by'
+  } else {
+    Set-ProjectFieldValueIfPresent -ProjectId $projectId -ItemId $itemId -FieldMap $fieldMap -FieldName 'Blocked by' -Value $blockedByText
+  }
+
+  if ([string]::IsNullOrWhiteSpace($blockingText)) {
+    Clear-ProjectFieldValueIfPresent -ProjectId $projectId -ItemId $itemId -FieldMap $fieldMap -FieldName 'Blocking'
+  } else {
+    Set-ProjectFieldValueIfPresent -ProjectId $projectId -ItemId $itemId -FieldMap $fieldMap -FieldName 'Blocking' -Value $blockingText
+  }
+
+  Set-ProjectFieldValueIfPresent -ProjectId $projectId -ItemId $itemId -FieldMap $fieldMap -FieldName 'Dependency Count' -Value ([string]$blockedByKeys.Count)
+  Set-ProjectFieldValueIfPresent -ProjectId $projectId -ItemId $itemId -FieldMap $fieldMap -FieldName 'Blocking Count' -Value ([string]$blockingKeys.Count)
+  Set-ProjectFieldValueIfPresent -ProjectId $projectId -ItemId $itemId -FieldMap $fieldMap -FieldName 'Child Issue Count' -Value ([string]$childKeys.Count)
+}
+
+Write-Step 'Linking native parent / sub-issue relationships'
+foreach ($issueDefinition in $orderedIssues) {
+  $parentKey = Get-PropertyValue -Object $issueDefinition -Name 'parentKey'
+  if ([string]::IsNullOrWhiteSpace($parentKey)) { continue }
+  $parentDefinition = $issueDefinitionsByKey[$parentKey]
+  $parentIssue = $existingIssuesByTitle[$parentDefinition.title]
+  $childIssue  = $existingIssuesByTitle[$issueDefinition.title]
+  if (-not $parentIssue -or -not $childIssue) { continue }
+  Set-NativeSubIssueLink -RepoOwner $repoInfo.Owner -RepoName $repoInfo.Name -ParentIssueNumber ([int]$parentIssue.number) -ChildIssueNumber ([int]$childIssue.number)
+}
+
+Write-Step 'Linking native issue dependencies'
+foreach ($issueDefinition in $orderedIssues) {
+  $blockedByKeys = @(Get-Collection (Get-PropertyValue -Object $issueDefinition -Name 'blockedByKeys'))
+  if ($blockedByKeys.Count -lt 1) { continue }
+
+  $issue = $existingIssuesByTitle[$issueDefinition.title]
+  if (-not $issue) { continue }
+
+  foreach ($blockedByKey in $blockedByKeys) {
+    $blockingDefinition = $issueDefinitionsByKey[$blockedByKey]
+    $blockingIssue = $existingIssuesByTitle[$blockingDefinition.title]
+    if (-not $blockingIssue) { continue }
+
+    Set-IssueBlockedByDependency -RepoFullName $repoInfo.FullName -IssueNumber ([int]$issue.number) -BlockingIssueNumber ([int]$blockingIssue.number)
   }
 }
 

--- a/scripts/setup-requirements-github-project.ps1
+++ b/scripts/setup-requirements-github-project.ps1
@@ -785,12 +785,12 @@ function Get-FieldMap {
 function Get-ExistingIssuesByTitle {
   param([string]$RepoFullName)
 
-  $issues = Get-Collection (Invoke-Gh -Arguments @('issue', 'list', '-R', $RepoFullName, '--state', 'open', '--limit', '500', '--json', 'number,title,url') -AsJson)
+  $issues = Get-Collection (Invoke-Gh -Arguments @('issue', 'list', '-R', $RepoFullName, '--state', 'all', '--limit', '500', '--json', 'number,title,url') -AsJson)
   $map = @{}
 
   foreach ($issue in $issues) {
     if ($map.ContainsKey($issue.title)) {
-      throw "Duplicate open issue title detected in ${RepoFullName}: $($issue.title). Remove or rename the duplicate before rerunning setup."
+      throw "Duplicate issue title detected in ${RepoFullName}: $($issue.title). Remove or rename the duplicate before rerunning setup."
     }
 
     $map[$issue.title] = $issue
@@ -1549,7 +1549,7 @@ function Get-ProjectViewsEndpoint {
     throw "Could not resolve numeric GitHub user id for $OwnerLogin."
   }
 
-  return "/users/$OwnerLogin/projectsV2/$ProjectNumber/views"
+  return "/users/$ownerId/projectsV2/$ProjectNumber/views"
 }
 
 function Resolve-ProjectViewFieldDatabaseIds {


### PR DESCRIPTION
﻿## Summary

This PR makes the thesis backlog governance setup reproducible from the repository seed.

- extends the requirements project schema with milestones, dependency links, richer view metadata, and dependency summary fields
- updates the requirements seed with three phase milestones, detailed Project views, native dependency definitions, and readable dependency/count fields
- patches the setup script to sync labels, milestones, parent/sub-issue links, issue dependencies, dependency summary fields, and Project views with BOM-free REST payloads
- documents the Project fields, views, API limits, and rerunnable setup behavior

## Cleanup

Temporary local artifacts were removed instead of being committed:

- `.tmp_advisor/`
- `issue_ids.json`
- `issues_parent.json`
- `milestone_assignments.json`
- `milestone_map.json`
- `parent_links.json`
- `project_items.json`

The advisor-review issue bodies and Project metadata were already pushed to GitHub, so these scratch files should not live in source control.

## Validation

- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\validate-github-governance.ps1 -Owner TurkishKEBAB`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\validate-doc-links.ps1`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\validate-plantuml.ps1`
- `git diff --check`

## Notes

GitHub's Project view API can create views and visible fields, but existing view updates and some group/sort/slice settings still require one final UI pass. The seed now records the intended configuration so that pass is documented.
